### PR TITLE
Changes made during pre-production (OpenStack) testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,16 +118,6 @@ if options[:local_zk_file] && !File.exists?(options[:local_zk_file])
   exit 3
 end
 
-if options[:node] && !(options[:node] =~ Resolv::IPv4::Regex)
-  print "ERROR; input node IP address #{options[:node]} is not a valid IP address\n"
-  exit 3
-end
-
-if options[:node] && options[:zookeeper_list]
-  print "ERROR; the node option and the zookeeper-list option cannot be combined\n"
-  exit 2
-end
-
 zookeeper_addr_array = []
 # if we're provisioning or an IP address is (or addresses are) required for this command,
 # then either the `--node` flag should be provided and only contain a single node or the
@@ -215,7 +205,7 @@ if zookeeper_addr_array.size > 0
     # `site.yml` playbook
     zookeeper_addr_array.each do |machine_addr|
       config.vm.provider "virtualbox" do |vb|
-        vb.memory = "256"
+        vb.memory = "2048"
       end
       config.vm.define machine_addr do |machine|
         # setup a private network for this machine

--- a/tasks/setup-zookeeper-server-properties.yml
+++ b/tasks/setup-zookeeper-server-properties.yml
@@ -79,4 +79,5 @@
     with_indexed_items: "{{zookeeper_nodes | default([])}}"
     when: "'{{iface_addr}}' == '{{item.1}}'"
   become: true
+  become_user: zookeeper
   when: (zookeeper_nodes | default([])) != []

--- a/vars/zookeeper.yml
+++ b/vars/zookeeper.yml
@@ -29,7 +29,7 @@ zookeeper_dir: "/opt/zookeeper"
 zookeeper_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 
 # used to set any JVM flags that should be used as part of the ZK configuration
-#jvm_flags: "-Xmx1g"
+jvm_flags: "-Xmx1g"
 
 # used to add extra repositories to the list of repositories in the
 # `local.repo` file that is deployed to a node when we're adding a


### PR DESCRIPTION
This PR includes a few small changes to the repository that were found to be necessary during testing in the pre-production (OpenStack) environment; specifically we:

* Cleaned up the Vagrantfile a bit to reflect changes that would be needed to simulate a production deployment and to remove a few remaining references to the old `--node` command-line flag (and the option setting that was used to track it's state)
* Increased the memory of the VM created in the Vagrantfile to 2GB (to reflect the sorts of machines that we would typically use in a Zookeeper ensemble in production)
* Uncommented the setting for the Java heap size that we plan on using in production
* Changed one of the tasks in our playbook so that it runs as the `zookeeper` user rather than running as `root`; without this change the Zookeeper cluster failed to start because the `myid` file created by that task was owned by root (and, as such, was not visible to the `zookeeper` user or the `zookeeper` service that we were starting using that user)