### PR TITLE
Modifications to use new build-app-host-groups common role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -239,7 +239,7 @@ if zookeeper_addr_array.size > 0
               local_zk_file: options[:local_zk_file],
               host_inventory: zookeeper_addr_array,
               reset_proxy_settings: options[:reset_proxy_settings],
-              inventory_type: "static"
+              cloud: "vagrant"
             }
             # if a Zookeeper data directory was set, then set an extra variable
             # containing the named directory

--- a/site.yml
+++ b/site.yml
@@ -1,75 +1,22 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-# If we're running this command for to build a cluster in an AWS or
-# OpenStack cloud, then use the `ec2` or `openstack` command (depending
-# on the `cloud` we're deploying into) to gather the dynamic inventory
-# information that we need to build our Zookeeper host group (and build it)
-- name: Create Zookeeper host group from AWS or OpenStack inventory
+# First, build our zookeeper host group
+- name: Create zookeeper host group
   hosts: "{{host_inventory}}"
   gather_facts: no
   tasks:
-    # run these commands to add the zookeeper host group for an aws cloud
-    - block:
-      - name: Run ec2 command to gather inventory information
-        local_action: "shell common-utils/inventory/aws/ec2"
-        register: di_output
-      - set_fact:
-          di_output_json: "{{di_output.stdout | from_json}}"
-      - set_fact:
-          cloud_nodes: "{{di_output_json | json_query('tag_Cloud_' + cloud)}}"
-          tenant_nodes: "{{di_output_json | json_query('tag_Tenant_' + tenant)}}"
-          project_nodes: "{{di_output_json | json_query('tag_Project_' + project)}}"
-          domain_nodes: "{{di_output_json | json_query('tag_Domain_' + domain)}}"
-          application_nodes: "{{di_output_json | json_query('tag_Application_' + application)}}"
-      - set_fact:
-          zookeeper_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "zookeeper"
-          ansible_ssh_user: "{{ansible_user}}"
-          ansible_ssh_private_key_file: "{{private_key_path}}/{{cloud}}-{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".ec2_key_name')}}-private-key.pem"
-        with_items: "{{zookeeper_nodes}}"
-      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "aws"
-      run_once: true
-    # or run these commands to add the zookeeper host group for an osp cloud
-    - block:
-      - name: Run openstack command to gather inventory information
-        local_action: "shell common-utils/inventory/osp/openstack"
-        register: di_output
-      - set_fact:
-          di_output_json: "{{di_output.stdout | from_json}}"
-      - set_fact:
-          cloud_nodes: "{{(di_output_json | json_query('[\"meta-Cloud_' + cloud + '\"]')).0}}"
-          tenant_nodes: "{{(di_output_json | json_query('[\"meta-Tenant_' + tenant + '\"]')).0}}"
-          project_nodes: "{{(di_output_json | json_query('[\"meta-Project_' + project + '\"]')).0}}"
-          domain_nodes: "{{(di_output_json | json_query('[\"meta-Domain_' + domain + '\"]')).0}}"
-          application_nodes: "{{(di_output_json | json_query('[\"meta-Application_' + application + '\"]')).0}}"
-      - set_fact:
-          zookeeper_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(domain_nodes) | intersect(application_nodes)}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "zookeeper"
-          ansible_ssh_user: "{{ansible_user}}"
-          ansible_ssh_private_key_file: "{{private_key_path}}/{{di_output_json | json_query('_meta.hostvars.\"' + item + '\".openstack.key_name')}}.pem"
-        with_items: "{{zookeeper_nodes}}"
-      when: not (inventory_type is undefined or inventory_type == "static") and cloud == "osp"
-      run_once: true
-
-# Otherwise, build our Zookeeper host group from the static inventory
-# information that was passed in
-- name: Create Zookeeper host group from static host_inventory list
-  hosts: "{{host_inventory}}"
-  gather_facts: no
-  tasks:
-    - block:
-      - set_fact:
-          zookeeper_nodes: "{{host_inventory}}"
-      - add_host:
-          name: "{{item}}"
-          groups: "zookeeper"
-        with_items: "{{zookeeper_nodes}}"
-      when: inventory_type == "static"
-      run_once: true
+    - include_role:
+        name: build-app-host-groups
+      vars:
+        host_group_list:
+          - name: zookeeper
+      when: cloud == 'aws' or cloud == 'osp'
+    - include_role:
+        name: build-app-host-groups
+      vars:
+        host_group_list:
+          - { name: zookeeper, node_list: "{{host_inventory}}" }
+      when: cloud == "vagrant"
 
 # Then, deploy Zookeeper to the nodes in the zookeeper host group that was passed in (if there
 # is more than one node passed in, those nodes will be configured as a single Zookeeper cluster)
@@ -91,6 +38,7 @@
   roles:
     - role: get-iface-addr
       iface_name: "{{zookeeper_iface}}"
+      as_fact: "zookeeper_addr"
     - role: setup-web-proxy
     - role: add-local-repository
       yum_repository: "{{yum_repo_url}}"
@@ -98,4 +46,3 @@
     - role: install-packages
       package_list: "{{combined_package_list}}"
     - role: dn-zookeeper
-      zookeeper_addr: "{{iface_addr}}"

--- a/tasks/setup-zookeeper-server-properties.yml
+++ b/tasks/setup-zookeeper-server-properties.yml
@@ -81,7 +81,7 @@
       regexp: "^[0-9]"
       line: "{{item.0}}"
     with_indexed_items: "{{zk_nodes | default([])}}"
-    when: "'{{iface_addr}}' == '{{item.1}}'"
+    when: "'{{zookeeper_addr}}' == '{{item.1}}'"
   become: true
   become_user: zookeeper
   when: (num_hosts | int) > 1


### PR DESCRIPTION
The changes in this pull request modify the existing `dn-zookeeper` role so that it uses the new `build-app-host-groups` common role to build out the `zookeeper` host group.  Specifically, this pull request:

* Modifies the existing Vagrantfile to use a `cloud = "vagrant"` extra variable to identify that a static inventory is being provided by vagrant
* Modifies the existing playbook in the `site.yml` file to use the new `build-app-host-groups` common role to build the `zookeeper` host group
* Uses the new version of the `get-iface-addr` common role to retrieve the zookeeper address in one step, rather than passing `iface_addr` the value into the `dn-zookeeper` role as a parameter named `zookeeper_addr`
* Modifies the `dn-zookeeper` role to remove a reference to the `iface_addr` value (even though we were passing that value in as the value of the `zookeeper_addr` fact, we never used it in the role; we were still using the `iface_addr` value internally).

These changes bring this role into line with the new way of obtaining facts about the underlying nodes, regardless of whether the inventory was passed in statically or obtained dynamically.