### PR TITLE
Modifications to standardize the playbook

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -33,6 +33,7 @@
         name: network
         state: restarted
       become: true
+      when: not (skip_network_restart is defined or skip_network_restart)
     - name: Gather facts from the Zookeeper node(s)
       setup:
   roles:

--- a/site.yml
+++ b/site.yml
@@ -36,6 +36,28 @@
       when: not (skip_network_restart is defined or skip_network_restart)
     - name: Gather facts from the Zookeeper node(s)
       setup:
+    # next, we obtain the interface names for our data_iface
+    # and api_iface (provided an interface description was provided for each)
+    - include_role:
+        name: get-iface-names
+      vars:
+        iface_descriptions: "{{iface_description_array}}"
+      when: not (iface_description_array is undefined or iface_description_array == [])
+    # if we're provisioning a RHEL machine, then we need to ensure that
+    # it's subscribed before we can install anything (if it hasn't been
+    # registered already, of course, if that's the case then we can skip
+    # this step)
+    - block:
+      - redhat_subscription:
+          state: present
+          username: "{{rhel_username}}"
+          password: "{{rhel_password}}"
+          consumer_id: "{{rhel_consumer_id}}"
+        become: true
+        when: rhel_username is defined and rhel_password is defined and rhel_consumer_id is defined
+      when: ansible_distribution == 'RedHat'
+  # Now that we have all of the facts we need, we can run the roles that are used to
+  # deploy and configure Zookeeper
   roles:
     - role: get-iface-addr
       iface_name: "{{zookeeper_iface}}"

--- a/vars/zookeeper.yml
+++ b/vars/zookeeper.yml
@@ -31,12 +31,6 @@ zookeeper_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 # used to set any JVM flags that should be used as part of the ZK configuration
 jvm_flags: "-Xmx1g"
 
-# used to add extra repositories to the list of repositories in the
-# `local.repo` file that is deployed to a node when we're adding a
-# local repository to use in the provisioning process
-#local_repository_url: http://{{yum_repository}}/local.repo
-#local_repository_extra_keys: http://{{yum_repository}}/local-keys.json
-
 # used to install Zookeeper from a file in a local directory (if it exists)
 local_zk_file: ""
 


### PR DESCRIPTION
The changes in this pull request bring the `dn-zookeeper` playbook in line with the other playbooks we are using today.  Specifically, this PR:

* adds a flag that can be used to skip the 'network restart' task in the playbook; while this task still runs by default, by setting the new `skip_network_restart` to `true` in the playbook run it will be skipped (something that might be useful for deployments where we know the nodes have already been setup properly, with IP addresses assigned to all of the NICs before the playbook is run).
* adds a task to the playbook run that can be used to register a RHEL7 node; this task is only executed if values are provided for the associated `rhel_username`, `rhel_password` and `rhel_consumer_id` parameters that are needed to register the node, and if any of these parameters are not defined (or if the node being provisioned is not a RedHat node) then that task will be skipped.
* brings the `common-roles` submodule up to date so that the playbook can use the new `get-iface-names` common role to obtain the names of a set of interfaces based on an interface description array
* adds code to the playbook to support passing in that array of interface descriptions (where each interface description is a hash map consisting of a `type`, `val`, and `as_var` value, where the last value is the name of the variable that the user wants that interface's name returned as; for example (in JSON), the following hash map can be used to obtain the names of two interfaces using the CIDR value associated with each NIC (the first name being returned as the `data_iface` and the second as the `api_iface`):
    ```
    iface_description_array: [
        { as_var: 'data_iface', type: 'cidr', val: '192.168.34.0/24' },
        { as_var: 'api_iface', type: 'cidr', val: '192.168.44.0/24'  }
    ]
    ```

With these changes in place, this role now supports the same capabilities that are supported by the other roles in use today.