### PR TITLE
Documentation updates and adding support for local variables file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,38 @@
 # dn-zookeeper
-Playbooks/Roles used to deploy Zookeeper
+Playbooks/Roles used to deploy [Apache Zookeeper](https://zookeeper.apache.org/)
 
 # Installation
-To install zookeeper using the `site.yml` playbook in this repository, first clone the contents of this repository to a local directory using a command like the following:
+To install Apache Zookeeper using the `site.yml` playbook in this repository, first clone the contents of this repository to a local directory using a command like the following:
+
 ```bash
 $ git clone --recursive https://github.com/Datanexus/dn-zookeeper
 ```
-That command will pull down the repository and it's submodules (currently the only dependency embedded as a submodule is the dependency on the `https://github.com/Datanexus/common-roles` repository).
+
+That command will pull down the repository and it's dependencies. Currently this playbook's only dependencies are on the [common-roles](https://github.com/Datanexus/common-roles) and [common-utils](https://github.com/Datanexus/common-utils) submodules in this repository. The first provides a set of common roles that are reused across the DataNexus playbooks, while the second provides a similar set of common utilities, including a pair of dynamic inventory scripts that can be used to control deployments made using this playbook in AWS and OpenStack environments.
+
+The only other requirements for using the playbook in this repository are a relatively recent (v2.x) release of Ansible. The easiest way to obtain a recent relese if Ansible is via a `pip install`, which requires that Python and pip are both installed locally. We have performed all of our testing using a recent (2.7.x) version of Python (Python 2); your mileage may vary if you attempt to run the playbook or the attached dynamic inventory scripts under a newer (v3.x) release of Python (Python 3).
 
 # Using this role to deploy Zookeeper
-The `site.yml` file at the top-level of this repository pulls in a set of default values for the parameters that are needed to deploy an Apache Zookeeper distribution from the `vars/zookeeper.yml` file.  The contents of that file currently look like this:
+The [site.yml](site.yml) file at the top-level of this repository supports the both single-node Zookeeper deployments and the deployment of multi-node Zookeeper ensembles. The process of deploying Zookeeper to these nodes will vary, depending on whether you are managing your inventory dynamically or statically (more on this topic [here](docs/Dynamic-vs-Static-Inventory.md)), whether you are performing a single-node deployment or are deploying a Zookeeper ensemble, and where you are downloading the packages and dependencies from that are needed to run Zookeeper on those nodes.
 
-```yaml
-# (c) 2016 DataNexus Inc.  All Rights Reserved
-#
-# Defaults that are necessary for all deployments of
-# zookeeper
----
-application: zookeeper
-# the directory where the Zookeeper logs will be written
-zookeeper_log_dir: /var/lib
-# the interface Zookeeper should listen on when running
-zookeeper_iface: eth0
-# the user that the zookeeper service should run under
-zookeeper_user: zookeeper
-# the following parameters are only used when provisioning an instance
-# of the apache distribution, but are uncommented here (regardless) to
-# provide reasonable default values when provisioning via Vagrant (where
-# the distribution being provisioned may be different from the default)
-zookeeper_version: "3.4.9"
-zookeeper_url: "https://www.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz"
-zookeeper_dir: "/opt/zookeeper"
-# these parameters are used for both confluent and apache distributions
-zookeeper_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
-# used to add extra repositories to the list of repositories in the
-# `local.repo` file that is deployed to a node when we're adding a
-# local repository to use in the provisioning process
-#local_repository_url: http://{{yum_repository}}/local.repo
-#local_repository_extra_keys: http://{{yum_repository}}/local-zeys.json
-# used to install zookeeper from the RPM files in a local directory (if it exists)
-local_zookeeper_package_path: ""
-```
+We discuss the various deployment scenarios supported by this playbook in [this document](docs/Deployment-Scenarios.md) and discuss how the [Vagrantfile](Vagrantfile) in this repository can be used to deploy Zookeeper (both single-node deployments and multi-node ensembles are supported) to a set of VMs hosted locally in VirtualBox [here](docs/Deployment-via-Vagrant.md).
 
-This default configuration defines default values for all of the parameters needed to deploy an instance of Apache Zookeeper to a node, including defining reasonable defaults for the network interface the Zookeeper instance should listen ("eth0" by default).  To deploy Apache Zookeeper to a node the IP address "192.168.34.8" using the role in this repository, one could simply run a command that looks like this:
+## Controlling the configuration
+This repository includes a default set of parameters defined in the [vars/zookeeper.yml](vars/zookeeper.yml) file that make it possible to perform deployments of Zookeeper out of the box with few, if any, changes necessary. If you are not happy with the default configuration defined in that file, there are a number of ways that you can customize the configuration used for your deployment, and which method you use is entirely up to you:
 
-```bash
-$ export ZOOKEEPER_ADDR="192.168.34.8"
-$ ansible-playbook -i "${ZOOKEEPER_ADDR}," -e "{host_inventory: ['${ZOOKEEPER_ADDR}']}" site.yml
-```
+* You can edit the [vars/zookeeper.yml](vars/zookeeper.yml) file to modify the default values that are defined in that file or define additional configuration parameters
+* You can override the values defined in that file or define additional configuration parameters by passing the values for those parameters into your `ansible-playbook` run on the command-line as extra variables
+* You can setup a *local variables file* on the local filesystem of the Ansible host that contains the values for the parameters you wish to set or customize, then pass the location of that file into your `ansible-playbook` command as an extra variable
 
-It should be noted here that any of the variables shown in the `vars/zookeeper.yml` file can be overridden on the command-line using the `--extra-vars` command-line flag.  As is the case with any other ansible-playbook run, the values defined on the command-line in this manner will override values defined in any of the `vars` files that are included in the playbook.  Keep in mind, however, that while this mechanism provides a simple method for overriding the underlying values defined in those `vars` files at runtime (without requiring that the underlying `vars` file be modified), the resulting configuration may be harder to track or reproduce over time (in a production deployment, for example) since the values that were set are not maintained under revision control.
+We have provided a summary of the configuration parameters that can be set (using any of these three methods) during an `ansible-playbook` run [here](docs/Supported-Config-Params.md). Overall, we have found the last option to be the easiest and most flexible of those three options. This is because:
+
+* It avoids modifying files that are being tracked under version control in the main, `dn-zookeeper` repository (the first option); making such changes will, more than likely, lead to conflicts at a later date when these files are modified in the main `dn-zookeeper` repository in a way that is inconsistent with the values that you have set in your clone, locally.
+* It lets you maintain your preferred configuration for any given Zookeeper deployment in the form of a configuration file, which you can easily maintain (along with the configuration files used for other deployments you have made) under version control in a separate repository
+* It provides a record of the configuration of any given deployment, which is in direct contrast to the second option (where the configuration parameters for any given deployment are passed in on the command-line as extra variables)
+
+That being said, the second option may be useful for some deployment scenarios (a one-off deployment of a local test environment, for example), so it remains a viable option for some users. Overall, we would recommend against trying to maintain your preferred cluster configuration using the values defined in the [vars/zookeeper.yml](vars/zookeeper.yml) file.
 
 # Assumptions
-It is assumed that this playbook will be run on a recent (systemd-based) version of RHEL or CentOS (RHEL-7.x or CentOS-7.x, for example); no support is provided for other distributions (and the `site.xml` playbook will not run successfully).  The examples shown above also assume that some (shared-key?) mechanism has been used to provide access to the Zookeeper host from the Ansible host that the ansible-playbook is being run on (if not, then additional arguments might be required to authenticate with that host from the Ansible host that are not shown in the example `ansible-playbook` commands shown above).
+It is assumed that this playbook will be run on a recent (systemd-based) version of RHEL or CentOS (RHEL-7.x or CentOS-7.x, for example); no support is provided for other distributions (and the `site.xml` playbook will not run successfully). Furthermore, it is assumed that you are interested in deploying a relatively recent version of Zookeeper using this playbook (the current default is v3.4.9 but any similar release should do).
 
-# Deployment via vagrant
-A Vagrantfile is included in this repository that can be used to deploy zookeeper to a VM using the `vagrant` command.  From the top-level directory of this repostory a command like the following will (by default) deploy Apache Zookeeper to a CentOS 7 virtual machine running under VirtualBox (assuming that both vagrant and VirtualBox are installed locally, of course):
-
-```bash
-$ vagrant -z="192.168.34.8" up
-```
-
-Note that the `-z` (or the corresponding `--zookeeper-addr`) flag must be used to pass an IP address into the Vagrantfile, and this IP address will be used as the IP address of the zookeeper server that is created by the vagrant command shown above.
-
-If the Vagrantfile in this repository is being used to deploy the Apache Zookeeper distribution to the specified node, then the command-line options shown above are the only variables that need to be defined.  However, there are two additional parameters that *may* be defined:  the `zookeeper_dir`, and `zookeeper_url` parameters.  As was mentioned earlier, default values for these two parameters are defined in the `vars/zookeeper.yml` file, and this file is pulled into the playbook contained in the `site.yml` file used by the Vagrantfile for provisioning.  As such, the Vagrantfile in this repository can be used (out of the box, so to speak) to deploy the Apache Zookeeper distribution to a node, without requiring editing of either the Vagrantfile or the `vars/zookeeper.yml` file.
-
-## Additional vagrant deployment options
-While the `vagrant up` command that is shown above can be used to easily deploy Apache Zookeeper to a node, the Vagrantfile included in this distribution also supports separating out the creation of the virtual machine from the provisioning of that virtual machine using the Ansible playbook contained in this repository's `site.yml` file. To create a virtual machine without provisioning it, simply run a command that looks something like this:
-
-```bash
-$ vagrant -z="192.168.34.8" up --no-provision
-```
-
-This will create a virtual machine with the appropriate IP address ("192.168.34.8"), but will skip the process of provisioning that VM with a Zookeeper distribution using the playbook in the `site.yml` file.  To provision that machine with a Confluent Zookeeper instance, you would simply run the following command:
-
-```bash
-$ vagrant -z="192.168.34.8" provision
-```
-
-That command will attach to the named instance (the VM at "192.168.34.8") and run the playbook in this repository's `site.yml` file on that node (resulting in the deployment of an instance of the Confluent Zookeeper distribution to that node).
-
-It should also be noted here that while the commands shown above will install Apache Zookeeper with a reasonable default configuration from a standard location, there are two additional command-line parameters that can be used to override the default values that are embedded in the Vagrantfile that is included as part of this distribution when we are deploying an instance of the Apache Zookeeper distribution:  the `-u` (or corresponding `--url`) flag and the `-p` (or corresponding `--path`) flag.  The `-u` flag can be used to override the default URL that is used to download the Apache Zookeeper distribution (the default URL points back to the main Apache Zookeeper distribution site), while the `-p` flag can be used to override the default path (`/opt/zookeeper`) that that the Apache Zookeeper gzipped tarfile is unpacked into during the provisioning process.
-
-As an example of how these options might be used, the following command will download the gzipped tarfile containing the Apache Zookeeper distribution from a local web server, rather than downloading it from the main Apache Zookeeper distribution site, when provisioning the VM with an IP address of `192.168.34.8` with an instance of the Apache Zookeeper distribution:
-
-```bash
-$ vagrant -z="192.168.34.8" -u="https://10.0.2.2/dist/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz" provision
-```
-
-Obviously, this option could prove to be quite useful in situations were we are deploying the distribution from a datacenter environment (where access to the internet may be restricted, or even unavailable).
+It should also be noted that in order to execute the vagrant commands shown in [this document](docs/Deployment-via-Vagrant.md) locally, recent versions of [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org) will have to be installed locally. While Vagrant does support management of Virtual Machines deployed via VMware Workstation and/or Fusion with the right (commercial) drivers in place, we have only tested the [Vagrantfile](Vagrantfile) in this repository under VirtualBox using recent (v1.9.x) releases of Vagrant.

--- a/docs/Deployment-Scenarios.md
+++ b/docs/Deployment-Scenarios.md
@@ -1,0 +1,130 @@
+# Example deployment scenarios
+
+There are a three basic deployment scenarios that are supported by this playbook. In the first two (shown below) we'll walk through the deployment of Zookeeper to a single node and the deployment of a multi-node Zookeeper ensemble using a static inventory file. Finally, in the third scenario we will show how the same multi-node Zookeeper cluster deployment shown in the second scenario could be performed using the dynamic inventory scripts for both AWS and OpenStack instead of a static inventory file.
+
+## Scenario #1: deploying Zookeeper to a single node
+While this is the simplest of the deployment scenarios that are supported by this playbook, it is more than likely that deployment of Zookeeper to a single node is really only only useful for very simple test environments. Nevertheless, we will start our discussion with this deployment scenario since it is the simplest.
+
+If we want to deploy Zookeeper to a single node with the IP address "192.168.34.12", we could simply create a very simple inventory file that looks something like the following:
+
+```bash
+$ cat single-node-inventory
+
+192.168.34.12 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/test_node_private_key'
+
+$ 
+```
+
+Note that in this example inventory file the `ansible_ssh_host` and `ansible_ssh_port` will take their default values since they aren't specified for our host in this very simple static inventory file. Once we've built our static inventory file, we can then deploy Zookeeper to our single node by running an `ansible-playbook` command that looks something like this:
+
+```bash
+$ ansible-playbook -i single-node-inventory -e "{ host_inventory: ['192.168.34.12'] }" site.yml
+```
+
+This will download the Apache Zookeeper distribution file from the default download server defined in the [vars/zookeeper.yml](../vars/zookeeper.yml) file, unpack that gzipped tarfile into the `/opt/apache-zookeeper` directory on that host, and configure that node as a single-node Zookeeper deployment, using the default configuration parameters that are defined in the [vars/zookeeper.yml](../vars/zookeeper.yml) file.
+
+## Scenario #2: deploying a multi-node Zookeeper ensemble
+If you are using this playbook to deploy a multi-node Zookeeper ensemble, then the configuration only slightly more complicated. The Zookeeper ensemble consists of a set of nodes that are configured to work together so that if any one node is lost the ensemble can continue to function.
+
+Let's assume that we are deploying Zookeeper to an ensemble made up of three nodes and, furthermore, let's assume that we're going to be using a static inventory file to control this deployment. The static inventory file that we will be using for this example looks like this:
+
+```bash
+$ cat test-cluster-inventory
+# example inventory file for a clustered deployment
+
+192.168.34.18 ansible_ssh_host= 192.168.34.18 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
+192.168.34.19 ansible_ssh_host= 192.168.34.19 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
+192.168.34.20 ansible_ssh_host= 192.168.34.20 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
+
+$
+```
+
+To deploy Zookeeper to the three nodes in our static inventory file and configure those nodes to work together as an ensemble, we'd run a command that looks something like this:
+
+```bash
+$ ansible-playbook -i test-cluster-inventory -e "{ \
+      host_inventory: ['192.168.34.18', '192.168.34.19', '192.168.34.20'], \
+      cloud: vagrant, zookeeper_iface: eth0, \
+      zookeeper_url: 'apache-zookeeper/zookeeper-3.4.9.tar.gz', \
+      yum_repo_url: 'http://192.168.34.254/centos', zookeeper_data_dir: '/data' \
+    }" site.yml
+```
+
+Alternatively, rather than passing all of those arguments in on the command-line as extra variables, we can make use of the *local variables file* support that is built into this playbook and construct a YAML file that looks something like this containing the configuration parameters that are being used for this deployment:
+
+```yaml
+cloud: vagrant
+zookeeper_iface: eth0
+zookeeper_url: 'apache-zookeeper/zookeeper-3.4.9.tar.gz'
+yum_repo_url: 'http://192.168.34.254/centos'
+zookeeper_data_dir: '/data'
+```
+
+and then we can pass in the *local variables file* as an argument to the `ansible-playbook` command; assuming the YAML file shown above was in the current working directory and was named `test-cluster-deployment-params.yml`, the resulting command would look somethin like this:
+
+```bash
+$ ansible-playbook -i test-cluster-inventory -e "{ \
+      host_inventory: ['192.168.34.18', '192.168.34.19', '192.168.34.20'], \
+      local_vars_file: 'test-cluster-deployment-params.yml' \
+    }" site.yml
+```
+
+Once that playbook run is complete, we can run the `zkServer.sh status` command on each of the nodes in our ensemble. This will show whether Zookeeper is running or not on each node and whether it is acting as a leader or follower:
+
+```bash
+$ ssh -i keys/zk_cluster_private_key cloud-user@192.168.34.18 "/opt/zookeeper/bin/zkServer.sh status"
+ZooKeeper JMX enabled by default
+Using config: /opt/zookeeper/bin/../conf/zoo.cfg
+Mode: follower
+$ ssh -i keys/zk_cluster_private_key cloud-user@192.168.34.19 "/opt/zookeeper/bin/zkServer.sh status"
+ZooKeeper JMX enabled by default
+Using config: /opt/zookeeper/bin/../conf/zoo.cfg
+Mode: follower
+$ ssh -i keys/zk_cluster_private_key cloud-user@192.168.34.20 "/opt/zookeeper/bin/zkServer.sh status"
+ZooKeeper JMX enabled by default
+Using config: /opt/zookeeper/bin/../conf/zoo.cfg
+Mode: leader
+$ 
+```
+
+This `ansible-playbook` command deployed Zookeeper to all three of our nodes and configured them as a single ensemble using a static inventory file to control the deployment.
+
+## Scenario #3: deploying a Zookeeper ensemble via dynamic inventory
+In this section we will repeat the multi-node cluster deployment that we just showed in the previous scenario, but we will use the dynamic inventory scripts provided in the [common-utils](../common-utils) submodule to control the deployment of our Zookeeper ensemble to an AWS or OpenStack environment rather than relying on a static inventory file.
+
+To accomplish this, the we have to:
+
+* Tag the instances in the AWS or OpenStack environment that we will be configuring as an ensemble with the appropriate `Tenant`, `Project`, `Domain`, and `Application` tags. Note that for all of the nodes we are targeting in our playbook runs, we will assign an `Application` tag of `zookeeper`
+* Once all of the nodes that will make up our cluster have been tagged appropriately, we can run `ansible-playbook` command similar to the first `ansible-playbook` command shown in the previous scenario; this will deploy Zookeeper to the nodes that make up our ensemble.
+
+In terms of what the commands look like, lets assume for this example that we've tagged the nodes that we are going to use to build our Zookeeper ensemble with the following VM tags:
+
+* **Tenant**: labs
+* **Project**: projectx
+* **Domain**: preprod
+* **Application**: zookeeper
+
+The `ansible-playbook` command used to deploy Zookeeper to target nodes in an OpenStack environment would then look something like this:
+
+```bash
+$ ansible-playbook -i common-utils/inventory/osp/openstack -e "{ \
+        host_inventory: 'meta-Application_zookeeper:&meta-Cloud_osp:&meta-Tenant_labs:&meta-Project_projectx:&meta-Domain_preprod', \
+        application: zookeeper, cloud: osp, tenant: labs, project: projectx, domain: preprod, \
+        private_key_path: './keys', ansible_user: cloud-user, \
+        zookeeper_iface: eth0, zookeeper_data_dir: '/data' \
+    }" site.yml
+```
+
+In an AWS environment, the `ansible-playbook` command looks quite similar:
+
+```bash
+$ ansible-playbook -i common-utils/inventory/aws/ec2 -e "{ \
+        host_inventory: 'tag_Application_zookeeper:&tag_Cloud_aws:&tag_Tenant_labs:&tag_Project_projectx:&tag_Domain_preprod', \
+        application: zookeeper, cloud: osp, tenant: labs, project: projectx, domain: preprod, \
+        private_key_path: './keys', ansible_user: cloud-user, \
+        zookeeper_iface: eth0, zookeeper_data_dir: '/data' \
+    }" site.yml
+```
+
+As you can see, it's basically the same commands that was shown for the OpenStack use case; they only differ in terms of the name of the inventory script passed in using the `-i, --inventory-file` command-line argument, the value passed in for `Cloud` tag (and the value for the associated `cloud` variable), and the prefix used when specifying the tags that should be matched in the `host_inventory` value (`tag_` instead of `meta-`). In both cases the result would be a set of nodes deployed as a Zookeeper ensemble, with the number of nodes in the ensemble determined (completely) by the tags that were assigned to them.
+

--- a/docs/Deployment-via-Vagrant.md
+++ b/docs/Deployment-via-Vagrant.md
@@ -1,0 +1,84 @@
+# Deployment via Vagrant
+A [Vagrantfile](../Vagrantfile) is included in this repository that can be used to deploy Zookeeper locally (to one or more VMs hosted under [VirtualBox](https://www.virtualbox.org/)) using [Vagrant](https://www.vagrantup.com/).  From the top-level directory of this repository a command like the following will (by default) deploy Zookeeper to a single CentOS 7 virtual machine running under VirtualBox:
+
+```bash
+$ vagrant -z="192.168.34.12" up
+```
+
+Note that the `-z, --zookeeper-list` flag must be used to pass an IP address (or a comma-separated list of IP addresses) into the [Vagrantfile](../Vagrantfile). In the example shown above, we are performing a single-node deployment of Zookeeper. When we are performing a multi-node deployment, then we simply pass in multiple addresses using the `-z, --zookeeper-list` command-line argument, as in this example:
+
+```bash
+vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" up
+```
+
+This command will create a three-node Zookeeper ensemble. It should be noted here that if any of the IP addresses in the Zookeeper list is not actually an IP address, then an error will be thrown.
+
+In terms of how it all works, the [Vagrantfile](../Vagrantfile) is written in such a way that the following sequence of events occurs when the `vagrant ... up` command shown above is run:
+
+1. All of the virtual machines in the ensemble (the addresses in the `-z, --zookeeper-list`) are created
+1. Zookeeper is deployed to each of those nodes and they are configured to talk to each other as members of the ensemble that is being built
+1. The `zookeeper` service is started on all of the nodes that were just provisioned
+
+As was the case with the second deployment scenario described [here](Deployment-Scenarios.md), once the nodes have been created and the playbook run is complete, we can run the `zkServer.sh status` command on each of the nodes in our ensemble. This will show whether Zookeeper is running or not on each node and whether it is acting as a leader or follower:
+
+```bash
+$ for host in 192.168.34.18 192.168.34.19 192.168.34.20; do
+    vagrant -z="$host" ssh -c "/opt/zookeeper/bin/zkServer.sh status"
+done
+ZooKeeper JMX enabled by default
+Using config: /opt/zookeeper/bin/../conf/zoo.cfg
+Mode: follower
+Connection to 127.0.0.1 closed.
+ZooKeeper JMX enabled by default
+Using config: /opt/zookeeper/bin/../conf/zoo.cfg
+Mode: follower
+Connection to 127.0.0.1 closed.
+ZooKeeper JMX enabled by default
+Using config: /opt/zookeeper/bin/../conf/zoo.cfg
+Mode: leader
+Connection to 127.0.0.1 closed.
+$
+```
+
+So, to recap, by using a single `vagrant ... up` command we were able to quickly spin up an ensemble consisting of of three Zookeeper nodes, and a similar `vagrant ... up` command could be used to build a similar Zookeeper ensemble consisting of any number of nodes.
+
+## Separating instance creation from provisioning
+While the `vagrant up` commands that are shown above can be used to easily deploy Zookeeper to a single node or to build a Zookeeper ensemble consisting of multiple nodes, the [Vagrantfile](../Vagrantfile) included in this distribution also supports separating out the creation of the virtual machine from the provisioning of that virtual machine using the Ansible playbook contained in this repository's [site.yml](../site.yml) file.
+
+To create a set of virtual machines that we plan on using to build a Zookeeper ensemble without provisioning Zookeeper to those machines, simply run a command similar to the following:
+
+```bash
+$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" up --no-provision
+```
+
+This will create a set of three virtual machines with the appropriate IP addresses ("192.168.34.18", "192.168.34.19", and "192.168.34.20"), but will skip the process of provisioning those VMs with an instance of Zookeeper.
+
+To provision the machines that were created above and configure those machines as a Zookeeper ensemble, we simply need to run a command like the following:
+
+```bash
+$ vagrant "192.168.34.18,192.168.34.19,192.168.34.20" provision
+```
+
+That command will attach to the named instances and run the playbook in this repository's [site.yml](../site.yml) file on those node, resulting in a Zookeeper ensemble consisting of the nodes that were created in the `vagrant ... up --no-provision` command that was shown, above.
+
+## Additional vagrant deployment options
+While the commands shown above will install Zookeeper with a reasonable, default configuration from a standard location, there are additional command-line parameters that can be used to override the default values that are embedded in the [vars/zookeeper.yml](../vars/zookeeper.yml) file. Here is a complete list of the command-line flags that can be included in any `vagrant ... up` or `vagrant ... provision` command:
+
+* **`-z, --zookeeper-list`**: the Zookeeper address list; this is the list of nodes that will be created and provisioned, either by a single `vagrant ... up` command or by a `vagrant ... up --no-provision` command followed by a `vagrant ... provision` command; this command-line flag **must** be provided for almost every `vagrant` command supported by the [Vagrantfile](../Vagrantfile) in this repository
+* **`-u, --url`**: the URL that the Apache Zookeeer distribution should be downloaded from. This flag can be useful in situations where there is limited (or no) internet access; in this situation the user may wish to download the distribution from a local web server rather than from the standard Zookeeper download site
+* **`-l, --local-zk-file`**: the path to a local (to the Ansible host) file containing the Apache Zookeeer distribution; this file will be uploaded to the target machines and unpacked into the `-p, --path` directory (see below). This flag can be useful in situations where there is limited (or no) internet access; in this situation the user may wish to upload the distribution from the Ansible host rather than downloading it from the standard Zookeeper download site
+* **`-p, --path`**: the path to the directory that the Zookeeper distribution should be unpacked into during the provisioning process; this defaults to the `/opt/zookeeper` directory if not specified
+* **`-d, --data`**: the path to the directory where Zookeeper will store it's data; this defaults to `/var/lib` if not specified
+* **`-y, --yum-url`**: the local YUM repository URL that should be used when installing packages during the node provisioning process. This can be useful when installing Zookeeper onto CentOS-based VMs in situations where there is limited (or no) internet access; in this situation the user might want to install packages from a local YUM repository instead of the standard CentOS mirrors. It should be noted here that this parameter is not used when installing Zookeeper on RHEL-based VMs; in such VMs this option will be silently ignored if set
+* **`-f, --local-vars-file`**: the *local variables file* that should be used when deploying the ensemble. A local variables file can be used to maintain the configuration parameter definitions that should be used for a given Zookeeper ensemble deployment, and values in this file will override any values that are either embedded in the [vars/zookeeper.yml](../vars/zookeeper.yml) file as defaults or passed into the `ansible-playbook` command as extra variables
+* **`-c, --clear-proxy-settings`**: if set, this command-line flag will cause the playbook to clear any proxy settings that may have been set on the machines being provisioned in a previous ansible-playbook run. This is useful for situations where an HTTP proxy might have been set incorrectly and, in a subsequent playbook run, we need to clear those settings before attempting to install any packages or download the Zookeeper distribution without an HTTP proxy
+
+As an example of how these options might be used, the following command will download the gzipped tarfile containing the Apache Zookeeper distribution from a local web server, rather than downloading it from the main Apache distribution site, configure Zookeeper to store it's data in the `/data` directory, and install packages from the CentOS mirror on the eb server at `http://192.168.34.254/centos` when provisioning the machines created by the `vagrant ... up --no-provision` command shown above:
+
+```bash
+$ vagrant -z="192.168.34.18,192.168.34.19,192.168.34.20" -d="/data" \
+    -l=/Users/tjmcs/tmp/local-gzipped-tarfiles/apache-zookeeper/zookeeper-3.4.9.tar.gz \
+    -y='http://192.168.34.254/centos' provision
+```
+
+While the list of command-line options defined above may not cover all of the customizations that user might want to make when performing production Zookeeper deployments, our hope is that the list shown above is more than sufficient for deploying Zookeeper ensembles using Vagrant for local testing purposes.

--- a/docs/Dynamic-vs-Static-Inventory.md
+++ b/docs/Dynamic-vs-Static-Inventory.md
@@ -1,0 +1,46 @@
+# Dynamic vs. static inventory
+The first decision to make is when using the playbook in this repository to deploy Zookeeper is whether you would like to manage the inventory for your deployments using the dynamic inventory scripts that are provided in the [common-utils](../common-utils) submodule for AWS and OpenStack environments or whether you are managing your inventory statically. Since the static inventory use case is the simplest, we'll start our discussion there. Then we'll move on to a discussion of how to control the deployment of Zookeeper in both AWS and OpenStack environments by tagging the VMs in those environments so that the dynamic inventory scripts from the [common-utils](../common-utils) submodule can be used to dynamically construct the lists of nodes that should be targeted by a given `ansible-playbook` run.
+
+## Managing deployments with static inventory files
+Let's assume that we are planning the deployment of a three-node Zookeeper ensemble using the playbook in this repository and we are planning on using a [static inventory file](https://docs.ansible.com/ansible/intro_inventory.html) to control that deployment. In this example (and others like it in this document) we'll assume that we're going to construct a single static inventory file (an INI-like formatted file containing the list of hosts that are targeted by any given playbook run), and then pass that file into the `ansible-playbook` command using the `-i, --inventory-file` command-line flag. The inventory file associated with our three-node Zookeeper cluster might look something like this:
+
+```bash
+$ cat test-cluster-inventory
+# example inventory file for a clustered deployment
+
+192.168.34.18 ansible_ssh_host= 192.168.34.18 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
+192.168.34.19 ansible_ssh_host= 192.168.34.19 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
+192.168.34.20 ansible_ssh_host= 192.168.34.20 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
+
+$
+```
+
+As you can see, our static inventory file consists of a list of the hosts that make up the inventory for our deployment. For each host in this file, we provide a list of the parameters that Ansible will need to connect to that host (INI-file style) as a set of `name=value` pairs. In this example, we've defined the following values for each of the entries in our static inventory file:
+
+* **`ansible_ssh_host`**: the hostname/address that Ansible should use to connect to the host; if not specified, the same hostname/address listed at the start of the line for that entry for that host will be used (in this example we are using IP addresses). This parameter can be important when there are multiple network interfaces on each host and only one of them (an admin network, for example) allows for SSH access
+* **`ansible_ssh_port`**: the port that Ansible should use when connecting to the host via SSH; if not specified, Ansible will attempt to connect using the default SSH port (port 22)
+* **`ansible_ssh_user`**: the username that Ansible should use when connecting to the host via SSH; if not specified, then the value of the global `ansible_user` variable will be used (this variable can be set as an extra variable in the `ansible-playbook` command if the same username is used for all hosts targeted by the playbook run)
+* **`ansible_ssh_private_key_file`**: the private key file that should be used when connecting to the host via SSH; if not specified, then the value of the global `ansible_ssh_private_key_file` variable will be used instead (this variable can be set as an extra variable in the `ansible-playbook` command if the same private key is used for all hosts targeted by the playbook run)
+
+With this static inventory file built, it's a relatively simple matter to deploy our Zookeeper ensemble using a single `ansible-playbook` command. Examples of these commands are shown [here](Deployment-Scenarios.md).
+
+## Managing deployments using dynamic inventory scripts
+For both AWS and OpenStack environments, the playbook in this repository supports the use of a [dynamic inventory](https://docs.ansible.com/ansible/intro_dynamic_inventory.html) to control deployments to those environments. This is accomplished by making use of the [build-app-host-groups](../common-roles/build-app-host-groups) common role, which in turn uses the dynamic inventory scripts that are included for these two types of environments in the [common-utils](../common-utils) submodule. These scripts return lists of the nodes that should be targeted by a given playbook run, and the [build-app-host-groups](../common-roles/build-app-host-groups) common role filters those lists, based on the tags that are assigned them and the tags that are included in the `ansible-playbook` command, to construct the host groups needed for a given deployment. This provides an attractive alternative to building static inventory files to control the deployment process in these environments, since the meta-data needed to determine which nodes should be targeted by a given playbook run is readily available in the framework itself.
+
+The process of using the [build-app-host-groups](../common-roles/build-app-host-groups) common role to control a playbook run starts out by tagging the VMs that are going to be the target of a particular deployment with the following tags:
+
+* **Tenant**: the tenant that will be using the Zookeeper ensemble being deployed. As an example, you might use a value of `labs` for this tag for Zookeeper ensembles that the Labs department in your organization will be using)
+* **Project**: this tag will be given the value of the project that will be using the Zookeeper ensemble that is being deployed; for example we might use the value `projectx` for this tag for ensembles that will be used for ProjectX
+* **Domain**: this tag is used to separate out the various domains that might be defined by the project team to control their deployments. For example, there might be separate ensembles built for `development`, `test`, `preprod`, and `production`. Each of these environments would be tagged appropriately based on their intended use.
+* **Application**: this tag is used to identify the application that should be deployed to a given virtual machine; in this playbook only nodes that are tagged as `zookeeper` nodes are targeted by default (and although the application name is something you could customize, we recommend against doing so)
+
+Once these tags have been assigned to the VMs that will be targeted by a given Zookeeper deployment, it is a relatively simple process to define values for the tags that should be targeted by the `ansible-playbook` command (as extra variables or in a *local variables file*, for example). Specifically, the following variables must be defined when using this dynamic inventory to manage a playbook run:
+
+* **tenant**
+* **project**
+* **domain**
+* **application**
+
+Note that the `application` value defaults to `zookeeper` (the default value defined at the top of the [vars/zookeeper.yml](../vars/zookeeper.yml) file), so this value does not really need to be redefined as part of the `ansible-playbook` command or in a or in a *local variables file*, but it is shown here for completeness.
+
+With these values assigned as part of the `ansible-playbook` command or in a or in a *local variables file*, the [build-app-host-groups](../common-roles/build-app-host-groups) role that is used by this playbook can correctly identify the nodes in the AWS or OpenStack environment that are targeted by a given playbook run and then use the resulting (dynamically constructed) lists of seed and non-seed nodes to control the deployment of Zookeeper to the nodes that will make up the ensemble being built.

--- a/docs/Supported-Config-Params.md
+++ b/docs/Supported-Config-Params.md
@@ -1,0 +1,63 @@
+# Supported configuration parameters
+The playbook in the [site.yml](../site.yml) file in this repository pulls in a set of default values for many of the configuration parameters that are needed to deploy Zookeeper from the [vars/zookeeper.yml](../vars/zookeeper.yml) file. The parameters defined in these files define a reasonable set of defaults for a fairly generic Zookeeper deployment, either to a single node or an ensemble, including defaults for the URL that the Zookeeper distribution should be downloaded from, the directory the distribution should be unpacked into, and the packages that must be installed on the node before the `zookeeper` service can be started.
+
+In addition to the defaults defined in the [vars/zookeeper.yml](../vars/zookeeper.yml) file, there are a large number of parameters that can be used to either control the deployment of Zookeeper to the nodes that will make up a ensemble during the `ansible-playbook` run or to configure those Zookeeper nodes once the installation is complete. In this section, we summarize all of these options, breaking them out into:
+
+* parameters used to control the `ansible-playbook` run
+* parameters used during the deployment process itself, and
+* parameters used to configure our Zookeeper nodes once Zookeeper has been installed locally.
+
+Each of these sets of parameters are described in their own section, below.
+
+## Parameters used to control the playbook run
+The following parameters can be used to control the `ansible-playbook` run itself, defining things like how Ansible should connect to the nodes involved in the playbook run, which nodes should be targeted, where the Zookeeper distribution should be downloaded from, which packages must be installed during the deployment process, and where those packages should be obtained from:
+
+* **`ansible_ssh_private_key_file`**: the location of the private key that should be used when connecting to the target nodes via SSH; this parameter is useful when there is one private key that is used to connect to all of the target nodes in a given playbook run
+* **`ansible_user`**: the username that should be used when connecting to the target nodes via SSH; is useful if the same username is used when connecting to all of the target nodes in a given playbook run
+* **`zookeeper_url`**: the URL that the Zookeeper distribution should be downloaded from
+* **`local_zk_file`**: the local file (to the Ansible host) containing the Zookeeper distribution; this file will be uploaded to the target hosts and unpacked into the `zookeeper_dir` (see below) during the playbook run
+* **`zookeeper_version`**: the version of Zookeeper that should be downloaded; used to switch versions when the distribution is downloaded using the default `zookeeper_url`, which is defined in the [vars/zookeeper.yml](../vars/zookeeper.yml) file
+* **`cloud`**: the name of the cloud type being targeted (`aws`, `osp`, or `vagrant`); this controls whether the inventory information for the playbook run is assumed to be passed in dynamically (when the cloud is `aws` or `osp`) or statically (if the cloud type is `vagrant`)
+* **`host_inventory`**: used to pass in a list of the nodes targeted for deployment (in the static inventory use case) or a union of the application, tenant, project, and domain tags (in the dynamic inventory use case)
+* **`local_vars_file`**: used to define the location of a *local variables file* (see the discussion of this topic, below); this file is a YAML file containing definitions for any of the configuration parameters that are described in this section and is more than likely a file that will be created to manage the process of creating a specific ensemble. Storing the settings for a given ensemble in such a file makes it easy to guarantee that all of the nodes in that ensemble are configured consistently
+* **`private_key_path`**: used to define the directory where the private keys are maintained when the inventory for the playbook run is being managed dynamically; in these cases, the scripts used to retrieve the dynamic inventory information will return the names of the keys that should be used to access each node, and the playbook will search the directory specified by this parameter to find the corresponding key files. If this value is not specified then the current working directory will be searched for those keys by default
+* **`proxy_env`**: a hash map that is used to define the proxy settings to use for downloading distribution files and installing packages; supports the `http_proxy`, `no_proxy`, `proxy_username`, and `proxy_password` fields as part of this hash map
+* **`reset_proxy_settings`**: used to reset any HTTP/YUM proxy settings that may have been made in a previous playbook run back to the defaults (no proxy); this is useful when a proxy was incorrectly set in a previous playbook run and the user wants to return to a "no-proxy" setup in the current playbook run
+* **`yum_repo_url`**: used to set the URL for a local YUM mirror. This parameter is only used for CentOS-based deployments; when deploying Zookeeper to RHEL-based nodes this parameter is silently ignored and the RHEL package repositories defined locally on the node will be used for any packages installed during the deployment process
+
+## Parameters used during the deployment process
+These parameters are used to control the deployment process itself, defining things like where to unpack the distribution into and what packages need to be installed as part of the deployment process:
+
+* **`zookeeper_dir`**: the path to the directory that the Apache Zookeeer distribution should be unpacked into; defaults to `/opt/zookeeper` if unspecified
+* **`zookeeper_user`**: the name of the user/group that should be used when unpacking the distribution and when running the `zookeeper` service
+* **`zookeeper_package_list`**: the list of packages that should be installed on the Zookeeper nodes; typically this parameter is left unchanged from the default (which installs the OpenJDK packages needed to run Zookeeper), but if it is modified the default, OpenJDK packages must be included as part of this list or an error will result when attempting to start the `zookeeper` service
+
+## Parameters used to configure the Zookeeper nodes
+These parameters are used configure the Zookeeper nodes themselves during a playbook run, defining things like the interface that Zookeeper should listen on for requests, the directory where Zookeper should store its data and logs, and the JVM flags that should be used when running Zookeeper:
+
+* **`zookeeper_iface`**: the name of the interface that the Zookeeper nodes should use when talking with each other and handling user requests. An interface of this name must exist for the playbook to run successfully, and if unspecified a value of `eth0` is assumed
+* **`iface_description_array`**: this parameter can be used in place of the `zookeeper_iface ` parameter described above; provides users with the ability to specify a description for this interface rather than identifying the interface by name (more on this, below)
+* **`zookeeper_data_dir`**: the name of the directory where Zookeeper should use to store its data; defaults to `/var/lib` if unspecified. If necessary, this directory will be created as part of the playbook run
+* **`zookeeper_data_log_dir`**: the name of the directory where Zookeeper should store it's transaction logs; defaults to `/var/log` if unspecified. If necessary, this directory will be created as part of the playbook run
+* **`jvm_flags`**: used to set any JVM flags that should be used as part of the Zookeeper configuration; defaults to `-Xmx1g` if inspecified
+
+## Interface names vs. interface descriptions
+For some operating systems on some platforms, it can be difficult (if not impossible) to determine the names of the interface that should be passed into the playbook using the `zookeeper_iface` parameter that was described, above. In those situations, the playbook in this repository provides an alternative; specifying those interfaces using the `iface_description_array` parameter instead.
+
+Put quite simply, the `iface_description_array` lets you specify a description for each of the networks that you are interested in, then retrieve the names of those networks on each machine in a variable that can be used elsewhere in the playbook. To accomplish this, the `iface_description_array` is defined as an array of hashes (one per interface), each of which include the following fields:
+
+* **`type`**: the type of description being provided, currently only the `cidr` type is supported
+* **`val`**: a value describing the network in question; since only `cidr` descriptions are currently supported, a CIDR value that looks something like `192.168.34.0/24` should be used for this field
+* **`as_var`**: the name of the variable that you would like the interface name returned as
+
+With these values in hand, the playbook will search the available networks on each machine and return a list of the interface names for each network that was described in the `iface_description_array` as the value of the fact named in the `as_var` field for that network's entry. For example, given this description:
+
+```json
+    iface_description_array: [
+        { as_var: 'zookeeper_iface', type: 'cidr', val: '192.168.34.0/24' },
+    ]
+```
+
+the playbook will return the name of the network that matches the CIDR `192.168.34.0/24` as the value of the `zookeeper_iface` fact. This fact can then be used later in the playbook to correctly configure the Zookeeper nodes to talk to each other and listen on the proper interface for user requests.
+
+It should be noted that if you choose to take this approach when constructing your `ansible-playbook` runs, a matching entry in the `iface_description_array` must be specified for the `zookeeper_iface` network, otherwise the default value of `eth0` will be used for this fact (and the playbook run may result in nodes that are at best misconfigured; if the `eth0` network does not exist then the playbook will fail to run altogether).

--- a/site.yml
+++ b/site.yml
@@ -1,10 +1,17 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
 ---
-# First, build our zookeeper host group
+# Build our zookeeper host group
 - name: Create zookeeper host group
   hosts: "{{host_inventory}}"
   gather_facts: no
   tasks:
+    # load the 'local variables file', if one was defined, to get any variables
+    # we might need from that file when constructing our host groups
+    - name: Load local variables file
+      include_vars:
+        file: "{{local_vars_file}}"
+      when: not (local_vars_file is undefined or local_vars_file is none or local_vars_file | trim == '')
+    # then, build our host groups
     - include_role:
         name: build-app-host-groups
       vars:
@@ -28,6 +35,15 @@
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(zookeeper_package_list) | union((install_packages_by_tag|default({})).zookeeper|default([])) }}"
   pre_tasks:
+    # first, load the local variables file (if one was defined); this will initialize
+    # the variables used in our playbook (and override any values in the 'vars/zookeeper.yml'
+    # file with redefined values from the 'local_vars_file', if any)
+    - name: Load local variables file (if defined)
+      include_vars:
+        file: "{{local_vars_file}}"
+      when: not (local_vars_file is undefined or local_vars_file is none or local_vars_file | trim == '')
+    # then, restart the network (unless the skip_network_restart was set)
+    # and gather some facts about our Zookeeper node(s)
     - name: Ensure the network interfaces are up on our Zookeeper node(s)
       service:
         name: network


### PR DESCRIPTION
The changes in this PR include the following:
* changes to bring the documentation up to date with the latest changes
* cleanup of the options in the `Vagrantfile` to bring them in line with the `Vagrantfiles` in our other playbooks
* adding support for a *local variables file* that can be used pass in options from a YAML file (something that can be maintained under version control external to this repository)