### PR TITLE
Changes to break out inventory_type from cloud type

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -249,12 +249,12 @@ if zookeeper_addr_array.size > 0
                 proxy_username: proxy_username,
                 proxy_password: proxy_password
               },
-              zookeeper_iface: "eth1",
+              data_iface: "eth1",
               yum_repo_url: options[:yum_repo_url],
               local_zk_file: options[:local_zk_file],
               host_inventory: zookeeper_addr_array,
               reset_proxy_settings: options[:reset_proxy_settings],
-              cloud: "vagrant"
+              inventory_type: "static"
             }
             # if a Zookeeper data directory was set, then set an extra variable
             # containing the named directory

--- a/docs/Deployment-Scenarios.md
+++ b/docs/Deployment-Scenarios.md
@@ -44,7 +44,7 @@ To deploy Zookeeper to the three nodes in our static inventory file and configur
 ```bash
 $ ansible-playbook -i test-cluster-inventory -e "{ \
       host_inventory: ['192.168.34.18', '192.168.34.19', '192.168.34.20'], \
-      cloud: vagrant, zookeeper_iface: eth0, \
+      inventory_type: static, data_iface: eth0, \
       zookeeper_url: 'apache-zookeeper/zookeeper-3.4.9.tar.gz', \
       yum_repo_url: 'http://192.168.34.254/centos', zookeeper_data_dir: '/data' \
     }" site.yml
@@ -53,8 +53,8 @@ $ ansible-playbook -i test-cluster-inventory -e "{ \
 Alternatively, rather than passing all of those arguments in on the command-line as extra variables, we can make use of the *local variables file* support that is built into this playbook and construct a YAML file that looks something like this containing the configuration parameters that are being used for this deployment:
 
 ```yaml
-cloud: vagrant
-zookeeper_iface: eth0
+inventory_type: static
+data_iface: eth0
 zookeeper_url: 'apache-zookeeper/zookeeper-3.4.9.tar.gz'
 yum_repo_url: 'http://192.168.34.254/centos'
 zookeeper_data_dir: '/data'
@@ -110,8 +110,8 @@ The `ansible-playbook` command used to deploy Zookeeper to target nodes in an Op
 $ ansible-playbook -i common-utils/inventory/osp/openstack -e "{ \
         host_inventory: 'meta-Application_zookeeper:&meta-Cloud_osp:&meta-Tenant_labs:&meta-Project_projectx:&meta-Domain_preprod', \
         application: zookeeper, cloud: osp, tenant: labs, project: projectx, domain: preprod, \
-        private_key_path: './keys', ansible_user: cloud-user, \
-        zookeeper_iface: eth0, zookeeper_data_dir: '/data' \
+        inventory_type: dynamic, private_key_path: './keys', ansible_user: cloud-user, \
+        data_iface: eth0, zookeeper_data_dir: '/data' \
     }" site.yml
 ```
 
@@ -121,8 +121,8 @@ In an AWS environment, the `ansible-playbook` command looks quite similar:
 $ ansible-playbook -i common-utils/inventory/aws/ec2 -e "{ \
         host_inventory: 'tag_Application_zookeeper:&tag_Cloud_aws:&tag_Tenant_labs:&tag_Project_projectx:&tag_Domain_preprod', \
         application: zookeeper, cloud: osp, tenant: labs, project: projectx, domain: preprod, \
-        private_key_path: './keys', ansible_user: cloud-user, \
-        zookeeper_iface: eth0, zookeeper_data_dir: '/data' \
+        inventory_type: dynamic, private_key_path: './keys', ansible_user: cloud-user, \
+        data_iface: eth0, zookeeper_data_dir: '/data' \
     }" site.yml
 ```
 

--- a/site.yml
+++ b/site.yml
@@ -17,18 +17,18 @@
       vars:
         host_group_list:
           - name: zookeeper
-      when: cloud == 'aws' or cloud == 'osp'
+      when: inventory_type == 'dynamic'
     - include_role:
         name: build-app-host-groups
       vars:
         host_group_list:
           - { name: zookeeper, node_list: "{{host_inventory}}" }
-      when: cloud == "vagrant"
+      when: inventory_type == 'static'
 
 # Then, deploy Zookeeper to the nodes in the zookeeper host group that was passed in (if there
 # is more than one node passed in, those nodes will be configured as a single Zookeeper cluster)
 - name: Install/configure servers (zookeeper)
-  hosts: zookeeper
+  hosts: zookeeper:&zookeeper_nodes
   gather_facts: no
   vars_files:
     - vars/zookeeper.yml
@@ -76,8 +76,8 @@
   # deploy and configure Zookeeper
   roles:
     - role: get-iface-addr
-      iface_name: "{{zookeeper_iface}}"
-      as_fact: "zookeeper_addr"
+      iface_name: "{{data_iface}}"
+      as_fact: "data_addr"
     - role: setup-web-proxy
     - role: add-local-repository
       yum_repository: "{{yum_repo_url}}"

--- a/tasks/setup-zookeeper-server-properties.yml
+++ b/tasks/setup-zookeeper-server-properties.yml
@@ -59,7 +59,7 @@
 # the zookeeper nodes we're provisioning as an ensemble
 - block:
   - set_fact:
-      zk_nodes: "{{zookeeper_nodes | map('extract', hostvars, [('ansible_' + zookeeper_iface), 'ipv4', 'address']) | list}}"
+      zk_nodes: "{{zookeeper_nodes | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
   - name: "Configure the zookeeper cluster timeouts"
     lineinfile:
       dest: "{{zookeeper_config_dir}}/zoo.cfg"
@@ -81,7 +81,7 @@
       regexp: "^[0-9]"
       line: "{{item.0}}"
     with_indexed_items: "{{zk_nodes | default([])}}"
-    when: "'{{zookeeper_addr}}' == '{{item.1}}'"
+    when: "'{{data_addr}}' == '{{item.1}}'"
   become: true
   become_user: zookeeper
   when: (num_hosts | int) > 1

--- a/vars/zookeeper.yml
+++ b/vars/zookeeper.yml
@@ -12,7 +12,7 @@ zookeeper_data_dir: /var/lib
 zookeeper_data_log_dir: /var/log
 
 # the interface Zookeeper should listen on when running
-zookeeper_iface: eth0
+data_iface: eth0
 
 # the user that the zookeeper service should run under
 zookeeper_user: zookeeper


### PR DESCRIPTION
The changes in this pull request update the `Vagrantfile`, `common-roles` submodule version, documentation, and playbook in this repository to support the new `inventory_type` parameter that was recently added to the `common-roles` submodule. With the changes in this pull request, this new parameter is now used to define whether the inventory in the playbook being managed statically (if the value is `static`) or dynamically (if the value is `dynamic`).

The `cloud` parameter that was previously used for this purpose and to describe how the inventory should be retrieved/parsed is now only used if the `inventory_type` is set to `dynamic` (in which case it can be either an `aws` or an `osp` cloud type).

In addition, we've modified playbook to use `data_iface` extra variable instead of `zookeeper_iface` (and to use the `data_addr` fact instead of the `zookeeper_addr` fact); this brings the name of this parameter inline with the other playbooks we've written, making it easier for users of multiple-playbooks to guess which parameters they should set in their `ansible-playbook` runs.

This PR also adds a filter to the hosts targeted by the deployment play (based on the `zookeeper_nodes` host group) so that only nodes in the input `host_inventory` will be targeted by the playbook run, regardless of how many nodes may be in the `zookeeper` host group in the inventory file that is passed in for the static inventory use case.

Finally, we have updated the documentation in this repository as part of this pull request to reflect this change to how the dynamic and static inventory use cases are handled during the playbook run.