### PR TITLE
Bug fix and restrict Zookeeper to only listen on the data_iface

### DIFF
--- a/tasks/setup-apache-zookeeper.yml
+++ b/tasks/setup-apache-zookeeper.yml
@@ -15,7 +15,7 @@
       dest: /tmp
       mode: 0644
       validate_certs: no
-    environment: "{{environment_vars}}"
+    environment: "{{environment_vars | default({})}}"
   - set_fact:
       local_filename: "{{zookeeper_url | basename}}"
   when: not(install_from_dir)
@@ -53,14 +53,10 @@
 # Now that we've installed the packages that we need, setup the appropriate `log`
 # directory for Zookeeper and finish by setting up some facts that we'll need later
 # in our playbook
-- set_fact: data_dir_location="/var/lib"
-- name: Set fact for the data directory location
-  set_fact: data_dir_location="{{zookeeper_data_dir}}"
-  when: not (zookeeper_data_dir is undefined or zookeeper_data_dir is none or zookeeper_data_dir | trim == '')
 - name: Ensure zookeeper data directory exists
   become: true
   file:
-    path: "{{data_dir_location}}/zookeeper"
+    path: "{{zookeeper_data_dir | default('/var/lib')}}/zookeeper"
     state: directory
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_user}}"

--- a/tasks/setup-zookeeper-server-properties.yml
+++ b/tasks/setup-zookeeper-server-properties.yml
@@ -17,12 +17,17 @@
     lineinfile:
       dest: "{{zookeeper_config_dir}}/zoo.cfg"
       regexp: "^dataDir"
-      line: "dataDir={{data_dir_location}}/zookeeper"
+      line: "dataDir={{zookeeper_data_dir | default('/var/lib')}}/zookeeper"
   - name: Configure zookeeper server to use the defined data log directory
     lineinfile:
       dest: "{{zookeeper_config_dir}}/zoo.cfg"
       regexp: "^dataLogDir"
       line: "dataLogDir={{zookeeper_data_log_dir}}/zookeeper"
+  - name: Configure the zookeeper clientPort to only listen on {{data_iface}}
+    lineinfile:
+      dest: "{{zookeeper_config_dir}}/zoo.cfg"
+      line: "clientPortAddress={{data_addr}}"
+      insertafter: "^clientPort="
   - name: Configure the maximum number of client connections
     lineinfile:
       dest: "{{zookeeper_config_dir}}/zoo.cfg"
@@ -35,7 +40,7 @@
       owner: "{{zookeeper_user}}"
       group: "{{zookeeper_user}}"
     with_items:
-      - "{{data_dir_location}}/zookeeper"
+      - "{{zookeeper_data_dir | default('/var/lib')}}/zookeeper"
       - "{{zookeeper_data_log_dir}}/zookeeper"
   become: true
 # if a set of JVM options were passed into the playbook run,
@@ -84,7 +89,7 @@
     with_indexed_items: "{{zk_nodes | default([])}}"
   - name: "Setup the 'myid' file for this zookeeper node"
     lineinfile:
-      dest: "{{data_dir_location}}/zookeeper/myid"
+      dest: "{{zookeeper_data_dir | default('/var/lib')}}/zookeeper/myid"
       create: yes
       regexp: "^[0-9]"
       line: "{{item.0 + ((existing_node_count | default('0')) | int)}}"


### PR DESCRIPTION
The changes in this pull request fix a bug in the provisioning playbook and configure Zookeeper to only listen on the `data_iface` by setting the `clientPortAddress` parameter. In addition, this pull request fixes a bug that was uncovered when running the existing playbook when no proxy information is passed in and removes an extraneous `data_dir_location` parameter.

To show the difference between the behavior of Zookeeper before and after the playbook run, the following pair of `grep` and `telnet` command show that when the provisioning playbook is run (before applying the changes in this pull request), Zookeeper is listening on all of the interfaces on the system (including the `127.0.0.1` interface):

```
$ vagrant -z=192.168.34.18 ssh
Last login: Mon Jun 19 02:21:53 2017 from 10.0.2.2
[vagrant@localhost ~]$ grep client /opt/zookeeper/conf/zoo.cfg
# the port at which the clients will connect
clientPort=2181
# the maximum number of client connections.
# increase this if you need to handle more clients
[vagrant@localhost ~]$ telnet localhost 2181
Trying ::1...
Connected to localhost.
Escape character is '^]'.
^]

telnet> quit
Connection closed.
[vagrant@localhost ~]$ 
```

When the same commands are run after applying the changes in this pull request (and re-running the provisioning playbook), Zookeeper is only listening on the `data_iface` inteface (`192.168.34.18` in this case): 

```
[vagrant@localhost ~]$ grep client /opt/zookeeper/conf/zoo.cfg
# the port at which the clients will connect
clientPort=2181
clientPortAddress=192.168.34.18
# the maximum number of client connections.
# increase this if you need to handle more clients
[vagrant@localhost ~]$ telnet localhost 2181
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
telnet: connect to address 127.0.0.1: Connection refused
[vagrant@localhost ~]$ telnet 192.168.34.18 2181
Trying 192.168.34.18...
Connected to 192.168.34.18.
Escape character is '^]'.
^]

telnet> quit
Connection closed.
[vagrant@localhost ~]$
```